### PR TITLE
Update loader.js

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -11,7 +11,7 @@ function mcDataToNode (mcData, mcVersion) {
     return indexes.blocksByName[name]
   }
   function getTexture (name) {
-    return findItemOrBlockByName(name).texture
+    return findItemOrBlockByName(name).texture.replace("minecraft:", "")
   }
   return {
     blocks: indexes.blocksByName,


### PR DESCRIPTION
When i try use the module, te texture get this url ´https://raw.githubusercontent.com/rom1504/minecraft-assets/master/data/1.20.2/minecraft:items/acacia_boat.png´. The prefix ´minecraft:´ is ​​the problem, even when reading it using getContent return erro trying search route `C:\..\AppData\Local\deno\npm\registry.npmjs.org\minecraft-assets\1.12.2\minecraft-assets\data\1.20.2\minecraft:items\acacia_boat\.png`