### PR TITLE
Add 26.1 to the version index

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,6 +176,13 @@ const data = {
     textureContent: require('./minecraft-assets/data/1.21.8/texture_content'),
     blocksStates: require('./minecraft-assets/data/1.21.8/blocks_states'),
     blocksModels: require('./minecraft-assets/data/1.21.8/blocks_models')
+  },
+  26.1: {
+    blocksTextures: require('./minecraft-assets/data/26.1/blocks_textures'),
+    itemsTextures: require('./minecraft-assets/data/26.1/items_textures'),
+    textureContent: require('./minecraft-assets/data/26.1/texture_content'),
+    blocksStates: require('./minecraft-assets/data/26.1/blocks_states'),
+    blocksModels: require('./minecraft-assets/data/26.1/blocks_models')
   }
 }
 


### PR DESCRIPTION
The 26.1 assets have shipped in the data submodule since 1.17.0 (PrismarineJS/minecraft-assets#50), but the version map in `index.js` was never updated, so `mcAssets('26.1')` returns `null` even though `data/26.1` is in the published package (verified against the 1.18.0 npm tarball).

Verified locally against the published 1.18.0 data: `mcAssets('26.1')` resolves all 1168 blocks, and prismarine-viewer's atlas/blocksStates generation (PrismarineJS/prismarine-viewer#484) completes for 26.1 with no missing textures.

Needed for PrismarineJS/prismarine-viewer#484 to work off a released minecraft-assets instead of locally generated data.